### PR TITLE
Use new timeago.js library

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "homepage": "https://github.com/parkr/hubot-github-pages",
   "dependencies": {
     "githubot": "~0.5.0",
-    "timeago": "~0.1.0"
+    "timeago.js": "~2.0.2"
   }
 }

--- a/src/github-pages.coffee
+++ b/src/github-pages.coffee
@@ -26,7 +26,7 @@
 # Author:
 #   parkr
 
-timeago = require('timeago')
+timeago = require('timeago.js')
 
 INFO_KEYS        = ["cname", "status", "custom_404"]
 INFO_COMMANDS    = ["info"].concat(INFO_KEYS)
@@ -59,7 +59,7 @@ fetch_from_info = (info, command) ->
     info
 
 formatted_build_text = (build) ->
-  "Page build #{build.status} @ #{build.commit.substr(0, 7)}. Triggered by #{build.pusher.login} #{timeago(build.created_at)}."
+  "Page build #{build.status} @ #{build.commit.substr(0, 7)}. Triggered by #{build.pusher.login} #{new timeago().format(build.created_at)}."
 
 formatted_versions = (versions) ->
   all = for gem, version of versions


### PR DESCRIPTION
Replace the heavy jQuery.timeago plugin with a smaller library [timeago.js](https://github.com/hustcc/timeago.js).

